### PR TITLE
XAPIC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A Rust interface to the x2apic interrupt architecture.
 This crate is in its early stages and has only been tested in QEMU; code
 contributions and bug reports are welcome.
 
-We currently require that processors support x2APIC mode.
+It will use x2APIC mode if supported by the CPU, otherwise it
+falls back to xAPIC mode.
 
 ## Usage
 

--- a/src/lapic/lapic_msr.rs
+++ b/src/lapic/lapic_msr.rs
@@ -6,70 +6,102 @@ use core::ops::Range;
 use paste;
 use x86_64::registers::model_specific::Msr;
 
+use crate::lapic::LocalApicMode;
+
+
+#[derive(Debug)]
+pub struct LocalApicRegister { msr: Msr, mmio_offset: u32 }
+
+impl LocalApicRegister {
+    pub fn new(register: (u32, u32)) -> Self {
+        Self { msr: Msr::new(register.0), mmio_offset: register.1 }
+    }
+
+    pub unsafe fn mmio_address(&self) -> u64 {
+        let base = Msr::new(IA32_APIC_BASE).read() & 0xFFFFFF000;
+        base + self.mmio_offset as u64
+    }
+
+    pub unsafe fn read(&self, mode: &LocalApicMode) -> u64 {
+        match mode {
+            LocalApicMode::XApic => *(self.mmio_address() as *const u64),
+            LocalApicMode::X2Apic => self.msr.read()
+        }
+    }
+
+    pub unsafe fn write(&mut self, mode: &LocalApicMode, value: u64) {
+        match mode {
+            LocalApicMode::XApic => { *(self.mmio_address() as *mut u64) = value },
+            LocalApicMode::X2Apic => self.msr.write(value)
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct LocalApicRegisters {
     base: Msr,
-    id: Msr,
-    version: Msr,
-    tpr: Msr,
-    ppr: Msr,
-    eoi: Msr,
-    ldr: Msr,
-    sivr: Msr,
-    isr0: Msr,
-    isr1: Msr,
-    isr2: Msr,
-    isr3: Msr,
-    isr4: Msr,
-    isr5: Msr,
-    isr6: Msr,
-    isr7: Msr,
-    tmr0: Msr,
-    tmr1: Msr,
-    tmr2: Msr,
-    tmr3: Msr,
-    tmr4: Msr,
-    tmr5: Msr,
-    tmr6: Msr,
-    tmr7: Msr,
-    irr0: Msr,
-    irr1: Msr,
-    irr2: Msr,
-    irr3: Msr,
-    irr4: Msr,
-    irr5: Msr,
-    irr6: Msr,
-    irr7: Msr,
-    error: Msr,
-    icr: Msr,
-    lvt_timer: Msr,
-    lvt_thermal: Msr,
-    lvt_perf: Msr,
-    lvt_lint0: Msr,
-    lvt_lint1: Msr,
-    lvt_error: Msr,
-    ticr: Msr,
-    tccr: Msr,
-    tdcr: Msr,
-    self_ipi: Msr,
+    id: LocalApicRegister,
+    version: LocalApicRegister,
+    tpr: LocalApicRegister,
+    ppr: LocalApicRegister,
+    eoi: LocalApicRegister,
+    ldr: LocalApicRegister,
+    sivr: LocalApicRegister,
+    isr0: LocalApicRegister,
+    isr1: LocalApicRegister,
+    isr2: LocalApicRegister,
+    isr3: LocalApicRegister,
+    isr4: LocalApicRegister,
+    isr5: LocalApicRegister,
+    isr6: LocalApicRegister,
+    isr7: LocalApicRegister,
+    tmr0: LocalApicRegister,
+    tmr1: LocalApicRegister,
+    tmr2: LocalApicRegister,
+    tmr3: LocalApicRegister,
+    tmr4: LocalApicRegister,
+    tmr5: LocalApicRegister,
+    tmr6: LocalApicRegister,
+    tmr7: LocalApicRegister,
+    irr0: LocalApicRegister,
+    irr1: LocalApicRegister,
+    irr2: LocalApicRegister,
+    irr3: LocalApicRegister,
+    irr4: LocalApicRegister,
+    irr5: LocalApicRegister,
+    irr6: LocalApicRegister,
+    irr7: LocalApicRegister,
+    error: LocalApicRegister,
+    icr: LocalApicRegister,
+    lvt_timer: LocalApicRegister,
+    lvt_thermal: LocalApicRegister,
+    lvt_perf: LocalApicRegister,
+    lvt_lint0: LocalApicRegister,
+    lvt_lint1: LocalApicRegister,
+    lvt_error: LocalApicRegister,
+    ticr: LocalApicRegister,
+    tccr: LocalApicRegister,
+    tdcr: LocalApicRegister,
+    self_ipi: LocalApicRegister,
 }
 
 macro_rules! read {
     ($name:ident) => {
         paste::item! {
-            pub unsafe fn $name(&self) -> u64 {
-                self.$name.read()
+            pub unsafe fn $name(&self, mode: &LocalApicMode) -> u64 {
+                self.$name.read(mode)
             }
 
-            pub unsafe fn [<$name _bit>](&self, bit: usize) -> bool {
-                self.$name().bit(bit)
+            pub unsafe fn [<$name _bit>](&self, mode: &LocalApicMode, bit: usize) -> bool {
+                self.$name(mode).bit(bit)
             }
 
             pub unsafe fn [<$name _bit_range>](
                 &self,
+                mode: &LocalApicMode,
                 pos: Range<usize>,
             ) -> u64 {
-                self.$name().bit_range(pos)
+                self.$name(mode).bit_range(pos)
             }
         }
     };
@@ -78,8 +110,8 @@ macro_rules! read {
 macro_rules! write {
     ($name:ident) => {
         paste::item! {
-            pub unsafe fn [<write_ $name>](&mut self, value: u64) {
-                self.$name.write(value);
+            pub unsafe fn [<write_ $name>](&mut self, mode: &LocalApicMode, value: u64) {
+                self.$name.write(mode, value);
             }
         }
     };
@@ -93,26 +125,28 @@ macro_rules! read_write {
         paste::item! {
             pub unsafe fn [<set_ $name _bit>](
                 &mut self,
+                mode: &LocalApicMode,
                 bit: usize,
                 val: bool,
             ) {
-                let mut reg_val = self.$name();
+                let mut reg_val = self.$name(mode);
 
                 reg_val.set_bit(bit, val);
 
-                self.[<write_ $name>](reg_val);
+                self.[<write_ $name>](mode, reg_val);
             }
 
             pub unsafe fn [<set_ $name _bit_range>](
                 &mut self,
+                mode: &LocalApicMode,
                 pos: Range<usize>,
                 val: u64,
             ) {
-                let mut reg_val = self.$name();
+                let mut reg_val = self.$name(mode);
 
                 reg_val.set_bit_range(pos, val);
 
-                self.[<write_ $name>](reg_val);
+                self.[<write_ $name>](mode, reg_val);
             }
         }
     };
@@ -122,53 +156,70 @@ impl LocalApicRegisters {
     pub fn new() -> Self {
         LocalApicRegisters {
             base: Msr::new(IA32_APIC_BASE),
-            id: Msr::new(ID),
-            version: Msr::new(VERSION),
-            tpr: Msr::new(TPR),
-            ppr: Msr::new(PPR),
-            eoi: Msr::new(EOI),
-            ldr: Msr::new(LDR),
-            sivr: Msr::new(SIVR),
-            isr0: Msr::new(ISR_0),
-            isr1: Msr::new(ISR_1),
-            isr2: Msr::new(ISR_2),
-            isr3: Msr::new(ISR_3),
-            isr4: Msr::new(ISR_4),
-            isr5: Msr::new(ISR_5),
-            isr6: Msr::new(ISR_6),
-            isr7: Msr::new(ISR_7),
-            tmr0: Msr::new(TMR_0),
-            tmr1: Msr::new(TMR_1),
-            tmr2: Msr::new(TMR_2),
-            tmr3: Msr::new(TMR_3),
-            tmr4: Msr::new(TMR_4),
-            tmr5: Msr::new(TMR_5),
-            tmr6: Msr::new(TMR_6),
-            tmr7: Msr::new(TMR_7),
-            irr0: Msr::new(IRR_0),
-            irr1: Msr::new(IRR_1),
-            irr2: Msr::new(IRR_2),
-            irr3: Msr::new(IRR_3),
-            irr4: Msr::new(IRR_4),
-            irr5: Msr::new(IRR_5),
-            irr6: Msr::new(IRR_6),
-            irr7: Msr::new(IRR_7),
-            error: Msr::new(ERROR),
-            icr: Msr::new(ICR),
-            lvt_timer: Msr::new(LVT_TIMER),
-            lvt_thermal: Msr::new(LVT_THERMAL),
-            lvt_perf: Msr::new(LVT_PERF),
-            lvt_lint0: Msr::new(LVT_LINT0),
-            lvt_lint1: Msr::new(LVT_LINT1),
-            lvt_error: Msr::new(LVT_ERROR),
-            ticr: Msr::new(TICR),
-            tccr: Msr::new(TCCR),
-            tdcr: Msr::new(TDCR),
-            self_ipi: Msr::new(SELF_IPI),
+            id: LocalApicRegister::new(ID),
+            version: LocalApicRegister::new(VERSION),
+            tpr: LocalApicRegister::new(TPR),
+            ppr: LocalApicRegister::new(PPR),
+            eoi: LocalApicRegister::new(EOI),
+            ldr: LocalApicRegister::new(LDR),
+            sivr: LocalApicRegister::new(SIVR),
+            isr0: LocalApicRegister::new(ISR_0),
+            isr1: LocalApicRegister::new(ISR_1),
+            isr2: LocalApicRegister::new(ISR_2),
+            isr3: LocalApicRegister::new(ISR_3),
+            isr4: LocalApicRegister::new(ISR_4),
+            isr5: LocalApicRegister::new(ISR_5),
+            isr6: LocalApicRegister::new(ISR_6),
+            isr7: LocalApicRegister::new(ISR_7),
+            tmr0: LocalApicRegister::new(TMR_0),
+            tmr1: LocalApicRegister::new(TMR_1),
+            tmr2: LocalApicRegister::new(TMR_2),
+            tmr3: LocalApicRegister::new(TMR_3),
+            tmr4: LocalApicRegister::new(TMR_4),
+            tmr5: LocalApicRegister::new(TMR_5),
+            tmr6: LocalApicRegister::new(TMR_6),
+            tmr7: LocalApicRegister::new(TMR_7),
+            irr0: LocalApicRegister::new(IRR_0),
+            irr1: LocalApicRegister::new(IRR_1),
+            irr2: LocalApicRegister::new(IRR_2),
+            irr3: LocalApicRegister::new(IRR_3),
+            irr4: LocalApicRegister::new(IRR_4),
+            irr5: LocalApicRegister::new(IRR_5),
+            irr6: LocalApicRegister::new(IRR_6),
+            irr7: LocalApicRegister::new(IRR_7),
+            error: LocalApicRegister::new(ERROR),
+            icr: LocalApicRegister::new(ICR),
+            lvt_timer: LocalApicRegister::new(LVT_TIMER),
+            lvt_thermal: LocalApicRegister::new(LVT_THERMAL),
+            lvt_perf: LocalApicRegister::new(LVT_PERF),
+            lvt_lint0: LocalApicRegister::new(LVT_LINT0),
+            lvt_lint1: LocalApicRegister::new(LVT_LINT1),
+            lvt_error: LocalApicRegister::new(LVT_ERROR),
+            ticr: LocalApicRegister::new(TICR),
+            tccr: LocalApicRegister::new(TCCR),
+            tdcr: LocalApicRegister::new(TDCR),
+            self_ipi: LocalApicRegister::new(SELF_IPI),
         }
     }
 
-    read_write!(base);
+    pub unsafe fn base(&self) -> u64 {
+        self.base.read()
+    }
+
+    pub unsafe fn base_bit(&self, bit: usize) -> bool {
+        self.base().bit(bit)
+    }
+
+    pub unsafe fn write_base(&mut self, value: u64) {
+        self.base.write(value)
+    }
+
+    pub unsafe fn set_base_bit(&mut self, bit: usize, value: bool) {
+        let mut base = self.base();
+        base.set_bit(bit, value);
+        self.write_base(base);
+    }
+
     read!(id);
     read!(version);
     read_write!(tpr);
@@ -346,56 +397,57 @@ impl IpiAllShorthand {
 
 pub const IA32_APIC_BASE: u32 = 0x1B;
 
-pub const ID: u32 = 0x802;
-pub const VERSION: u32 = 0x803;
-pub const TPR: u32 = 0x808;
-pub const PPR: u32 = 0x80A;
-pub const EOI: u32 = 0x80B;
-pub const LDR: u32 = 0x80D;
-pub const SIVR: u32 = 0x80F;
+// format is (X2APIC MSR, XAPIC MMIO offset)
+pub const ID: (u32, u32) = (0x802, 0x020);
+pub const VERSION: (u32, u32) = (0x803, 0x030);
+pub const TPR: (u32, u32) = (0x808, 0x080);
+pub const PPR: (u32, u32) = (0x80A, 0x0A0);
+pub const EOI: (u32, u32) = (0x80B, 0x0B0);
+pub const LDR: (u32, u32) = (0x80D, 0x0D0);
+pub const SIVR: (u32, u32) = (0x80F, 0x0F0);
 
-pub const ISR_0: u32 = 0x810;
-pub const ISR_1: u32 = 0x811;
-pub const ISR_2: u32 = 0x812;
-pub const ISR_3: u32 = 0x813;
-pub const ISR_4: u32 = 0x814;
-pub const ISR_5: u32 = 0x815;
-pub const ISR_6: u32 = 0x816;
-pub const ISR_7: u32 = 0x817;
+pub const ISR_0: (u32, u32) = (0x810, 0x100);
+pub const ISR_1: (u32, u32) = (0x811, 0x110);
+pub const ISR_2: (u32, u32) = (0x812, 0x120);
+pub const ISR_3: (u32, u32) = (0x813, 0x130);
+pub const ISR_4: (u32, u32) = (0x814, 0x140);
+pub const ISR_5: (u32, u32) = (0x815, 0x150);
+pub const ISR_6: (u32, u32) = (0x816, 0x160);
+pub const ISR_7: (u32, u32) = (0x817, 0x170);
 
-pub const TMR_0: u32 = 0x818;
-pub const TMR_1: u32 = 0x819;
-pub const TMR_2: u32 = 0x81A;
-pub const TMR_3: u32 = 0x81B;
-pub const TMR_4: u32 = 0x81C;
-pub const TMR_5: u32 = 0x81D;
-pub const TMR_6: u32 = 0x81E;
-pub const TMR_7: u32 = 0x81F;
+pub const TMR_0: (u32, u32) = (0x818, 0x180);
+pub const TMR_1: (u32, u32) = (0x819, 0x190);
+pub const TMR_2: (u32, u32) = (0x81A, 0x1A0);
+pub const TMR_3: (u32, u32) = (0x81B, 0x1B0);
+pub const TMR_4: (u32, u32) = (0x81C, 0x1C0);
+pub const TMR_5: (u32, u32) = (0x81D, 0x1D0);
+pub const TMR_6: (u32, u32) = (0x81E, 0x1E0);
+pub const TMR_7: (u32, u32) = (0x81F, 0x1F0);
 
-pub const IRR_0: u32 = 0x820;
-pub const IRR_1: u32 = 0x821;
-pub const IRR_2: u32 = 0x822;
-pub const IRR_3: u32 = 0x823;
-pub const IRR_4: u32 = 0x824;
-pub const IRR_5: u32 = 0x825;
-pub const IRR_6: u32 = 0x826;
-pub const IRR_7: u32 = 0x827;
+pub const IRR_0: (u32, u32) = (0x820, 0x200);
+pub const IRR_1: (u32, u32) = (0x821, 0x210);
+pub const IRR_2: (u32, u32) = (0x822, 0x220);
+pub const IRR_3: (u32, u32) = (0x823, 0x230);
+pub const IRR_4: (u32, u32) = (0x824, 0x240);
+pub const IRR_5: (u32, u32) = (0x825, 0x250);
+pub const IRR_6: (u32, u32) = (0x826, 0x260);
+pub const IRR_7: (u32, u32) = (0x827, 0x270);
 
-pub const ERROR: u32 = 0x828;
-pub const ICR: u32 = 0x830;
+pub const ERROR: (u32, u32) = (0x828, 0x280);
+pub const ICR: (u32, u32) = (0x830, 0x300);
 
-pub const LVT_TIMER: u32 = 0x832;
-pub const LVT_THERMAL: u32 = 0x833;
-pub const LVT_PERF: u32 = 0x834;
-pub const LVT_LINT0: u32 = 0x835;
-pub const LVT_LINT1: u32 = 0x836;
-pub const LVT_ERROR: u32 = 0x837;
+pub const LVT_TIMER: (u32, u32) = (0x832, 0x320);
+pub const LVT_THERMAL: (u32, u32) = (0x833, 0x330);
+pub const LVT_PERF: (u32, u32) = (0x834, 0x340);
+pub const LVT_LINT0: (u32, u32) = (0x835, 0x350);
+pub const LVT_LINT1: (u32, u32) = (0x836, 0x360);
+pub const LVT_ERROR: (u32, u32) = (0x837, 0x370);
 
-pub const TICR: u32 = 0x838;
-pub const TCCR: u32 = 0x839;
-pub const TDCR: u32 = 0x83E;
+pub const TICR: (u32, u32) = (0x838, 0x380);
+pub const TCCR: (u32, u32) = (0x839, 0x390);
+pub const TDCR: (u32, u32) = (0x83E, 0x3E0);
 
-pub const SELF_IPI: u32 = 0x83F;
+pub const SELF_IPI: (u32, u32) = (0x83F, 0xFFFF);
 
 // Register bits and bit ranges.
 

--- a/src/lapic/mod.rs
+++ b/src/lapic/mod.rs
@@ -11,9 +11,21 @@ pub use lapic_msr::{
     ErrorFlags, IpiAllShorthand, IpiDestMode, TimerDivide, TimerMode,
 };
 
+/// Specifies which version of the APIC specification we are operating in
+#[derive(Debug, PartialEq)]
+pub enum LocalApicMode {
+    /// Extended APIC (XAPIC)
+    XApic,
+
+    /// Extended XAPIC (X2APIC)
+    X2Apic
+}
+
 /// The local APIC structure.
 #[derive(Debug)]
 pub struct LocalApic {
+    mode: LocalApicMode,
+
     timer_vector: usize,
     error_vector: usize,
     spurious_vector: usize,
@@ -33,7 +45,9 @@ impl LocalApic {
     /// Turns on the APIC timer and disables the `LINT0` and `LINT1` local
     /// interrupts.
     pub unsafe fn enable(&mut self) {
-        self.x2apic_mode_enable();
+        if self.mode == LocalApicMode::X2Apic {
+            self.x2apic_mode_enable();
+        }
 
         self.remap_lvt_entries();
 
@@ -52,7 +66,7 @@ impl LocalApic {
 
     /// Signals end-of-interrupt to the local APIC.
     pub unsafe fn end_of_interrupt(&mut self) {
-        self.regs.write_eoi(0);
+        self.regs.write_eoi(&self.mode, 0);
     }
 
     /// Is this processor the BSP?
@@ -62,64 +76,64 @@ impl LocalApic {
 
     /// Returns the local APIC ID.
     pub unsafe fn id(&self) -> u32 {
-        self.regs.id() as u32
+        self.regs.id(&self.mode) as u32
     }
 
     /// Returns the version number of the local APIC.
     pub unsafe fn version(&self) -> u8 {
-        self.regs.version_bit_range(VERSION_NR) as u8
+        self.regs.version_bit_range(&self.mode, VERSION_NR) as u8
     }
 
     /// Returns the maximum local vector table entry.
     pub unsafe fn max_lvt_entry(&self) -> u8 {
-        self.regs.version_bit_range(VERSION_MAX_LVT_ENTRY) as u8
+        self.regs.version_bit_range(&self.mode, VERSION_MAX_LVT_ENTRY) as u8
     }
 
     /// Does this processor support EOI-broadcast suppression?
     pub unsafe fn has_eoi_bcast_suppression(&self) -> bool {
-        self.regs.version_bit(VERSION_EOI_BCAST_SUPPRESSION)
+        self.regs.version_bit(&self.mode, VERSION_EOI_BCAST_SUPPRESSION)
     }
 
     /// Returns error flags from the error status register.
     pub unsafe fn error_flags(&self) -> ErrorFlags {
-        ErrorFlags::from_bits_truncate(self.regs.error() as u8)
+        ErrorFlags::from_bits_truncate(self.regs.error(&self.mode) as u8)
     }
 
     /// Enable the APIC timer.
     pub unsafe fn enable_timer(&mut self) {
-        self.regs.set_lvt_timer_bit(LVT_TIMER_MASK, false);
+        self.regs.set_lvt_timer_bit(&self.mode, LVT_TIMER_MASK, false);
     }
 
     /// Disable the APIC timer.
     pub unsafe fn disable_timer(&mut self) {
-        self.regs.set_lvt_timer_bit(LVT_TIMER_MASK, true);
+        self.regs.set_lvt_timer_bit(&self.mode, LVT_TIMER_MASK, true);
     }
 
     /// Sets the timer mode.
     pub unsafe fn set_timer_mode(&mut self, mode: TimerMode) {
         self.timer_mode = mode;
         self.regs
-            .set_lvt_timer_bit_range(LVT_TIMER_MODE, mode.into_u64());
+            .set_lvt_timer_bit_range(&self.mode, LVT_TIMER_MODE, mode.into_u64());
     }
 
     /// Sets the timer divide configuration.
     pub unsafe fn set_timer_divide(&mut self, divide: TimerDivide) {
         self.timer_divide = divide;
         self.regs
-            .set_tdcr_bit_range(TDCR_DIVIDE_VALUE, divide.into_u64());
+            .set_tdcr_bit_range(&self.mode, TDCR_DIVIDE_VALUE, divide.into_u64());
     }
 
     /// Sets the timer initial count.
     pub unsafe fn set_timer_initial(&mut self, initial: u32) {
         self.timer_initial = initial;
-        self.regs.write_ticr(u64::from(initial));
+        self.regs.write_ticr(&self.mode, u64::from(initial));
     }
 
     /// Sets the logical x2APIC ID.
     ///
     /// This is used when the APIC is in logical mode.
     pub unsafe fn set_logical_id(&mut self, dest: u32) {
-        self.regs.write_ldr(u64::from(dest));
+        self.regs.write_ldr(&self.mode, u64::from(dest));
     }
 
     /// Sends an IPI to the processor(s) in `dest`.
@@ -127,7 +141,7 @@ impl LocalApic {
         let mut icr_val = self.format_icr(vector, IpiDeliveryMode::Fixed);
 
         icr_val.set_bit_range(ICR_DESTINATION, u64::from(dest));
-        self.regs.write_icr(icr_val);
+        self.regs.write_icr(&self.mode, icr_val);
     }
 
     /// Sends an IPI to every processor, either including or excluding the
@@ -136,7 +150,7 @@ impl LocalApic {
         let mut icr_val = self.format_icr(vector, IpiDeliveryMode::Fixed);
 
         icr_val.set_bit_range(ICR_DEST_SHORTHAND, who.into_u64());
-        self.regs.write_icr(icr_val);
+        self.regs.write_icr(&self.mode, icr_val);
     }
 
     /// Send a lowest-priority IPI to the processor(s) in `dest`.
@@ -145,7 +159,7 @@ impl LocalApic {
             self.format_icr(vector, IpiDeliveryMode::LowestPriority);
 
         icr_val.set_bit_range(ICR_DESTINATION, u64::from(dest));
-        self.regs.write_icr(icr_val);
+        self.regs.write_icr(&self.mode, icr_val);
     }
 
     /// Send a lowest-priority IPI to all processors, either including or
@@ -159,7 +173,7 @@ impl LocalApic {
             self.format_icr(vector, IpiDeliveryMode::LowestPriority);
 
         icr_val.set_bit_range(ICR_DEST_SHORTHAND, who.into_u64());
-        self.regs.write_icr(icr_val);
+        self.regs.write_icr(&self.mode, icr_val);
     }
 
     /// Sends a system management IPI to `dest`.
@@ -167,7 +181,7 @@ impl LocalApic {
         let mut icr_val = self.format_icr(0, IpiDeliveryMode::SystemManagement);
 
         icr_val.set_bit_range(ICR_DESTINATION, u64::from(dest));
-        self.regs.write_icr(icr_val);
+        self.regs.write_icr(&self.mode, icr_val);
     }
 
     /// Sends a system management IPI to all processors, either including or
@@ -176,7 +190,7 @@ impl LocalApic {
         let mut icr_val = self.format_icr(0, IpiDeliveryMode::SystemManagement);
 
         icr_val.set_bit_range(ICR_DEST_SHORTHAND, who.into_u64());
-        self.regs.write_icr(icr_val);
+        self.regs.write_icr(&self.mode, icr_val);
     }
 
     /// Sends a non-maskable interrupt to the processor(s) in `dest`.
@@ -184,7 +198,7 @@ impl LocalApic {
         let mut icr_val = self.format_icr(0, IpiDeliveryMode::NonMaskable);
 
         icr_val.set_bit_range(ICR_DESTINATION, u64::from(dest));
-        self.regs.write_icr(icr_val);
+        self.regs.write_icr(&self.mode, icr_val);
     }
 
     /// Sends a non-maskable interrupt to all processors, either including or
@@ -193,7 +207,7 @@ impl LocalApic {
         let mut icr_val = self.format_icr(0, IpiDeliveryMode::NonMaskable);
 
         icr_val.set_bit_range(ICR_DEST_SHORTHAND, who.into_u64());
-        self.regs.write_icr(icr_val);
+        self.regs.write_icr(&self.mode, icr_val);
     }
 
     /// Sends a start-up IPI to the processors in `dest`.
@@ -201,7 +215,7 @@ impl LocalApic {
         let mut icr_val = self.format_icr(vector, IpiDeliveryMode::StartUp);
 
         icr_val.set_bit_range(ICR_DESTINATION, u64::from(dest));
-        self.regs.write_icr(icr_val);
+        self.regs.write_icr(&self.mode, icr_val);
     }
 
     /// Sends a start-up IPI to all other processors.
@@ -212,12 +226,12 @@ impl LocalApic {
             ICR_DEST_SHORTHAND,
             IpiAllShorthand::AllExcludingSelf.into_u64(),
         );
-        self.regs.write_icr(icr_val);
+        self.regs.write_icr(&self.mode, icr_val);
     }
 
     /// Issues an IPI to itself on vector `irq`.
     pub unsafe fn send_ipi_self(&mut self, vector: u8) {
-        self.regs.write_self_ipi(u64::from(vector));
+        self.regs.write_self_ipi(&self.mode, u64::from(vector));
     }
 
     fn format_icr(&self, vector: u8, mode: IpiDeliveryMode) -> u64 {
@@ -240,32 +254,32 @@ impl LocalApic {
     }
 
     unsafe fn software_enable(&mut self) {
-        self.regs.set_sivr_bit(SIVR_APIC_SOFTWARE_ENABLE, true);
+        self.regs.set_sivr_bit(&self.mode, SIVR_APIC_SOFTWARE_ENABLE, true);
     }
 
     unsafe fn remap_lvt_entries(&mut self) {
         self.regs.set_lvt_timer_bit_range(
+            &self.mode,
             LVT_TIMER_VECTOR,
             self.timer_vector as u64,
         );
         self.regs.set_lvt_error_bit_range(
+            &self.mode,
             LVT_ERROR_VECTOR,
             self.error_vector as u64,
         );
         self.regs
-            .set_sivr_bit_range(SIVR_VECTOR, self.spurious_vector as u64);
+            .set_sivr_bit_range(&self.mode, SIVR_VECTOR, self.spurious_vector as u64);
     }
 
     unsafe fn configure_timer(&mut self) {
-        self.regs
-            .set_lvt_timer_bit_range(LVT_TIMER_MODE, self.timer_mode.into_u64());
-        self.regs
-            .set_tdcr_bit_range(TDCR_DIVIDE_VALUE, self.timer_divide.into_u64());
-        self.regs.write_ticr(u64::from(self.timer_initial));
+        self.regs.set_lvt_timer_bit_range(&self.mode, LVT_TIMER_MODE, self.timer_mode.into_u64());
+        self.regs.set_tdcr_bit_range(&self.mode, TDCR_DIVIDE_VALUE, self.timer_divide.into_u64());
+        self.regs.write_ticr(&self.mode, u64::from(self.timer_initial));
     }
 
     unsafe fn disable_local_interrupt_pins(&mut self) {
-        self.regs.write_lvt_lint0(0);
-        self.regs.write_lvt_lint1(0);
+        self.regs.write_lvt_lint0(&self.mode, 0);
+        self.regs.write_lvt_lint1(&self.mode, 0);
     }
 }


### PR DESCRIPTION
This PR adds support for XAPIC mode when X2APIC is not supported.

From what I understand, QEMU only supports X2APIC when running in KVM (i.e, Linux). Since I'm using OS X as a development environment it's not available for me.
