### PR TITLE
update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ license = "MIT/Apache-2.0"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-x86_64 = "0.7.1"
-raw-cpuid = "6.1.0"
+x86_64 = "0.11"
+raw-cpuid = "8.1"
 bit = "0.1.1"
-bitflags = "1.1.0"
-paste = "0.1.5"
+bitflags = "1.2"
+paste = "0.1"


### PR DESCRIPTION
the previous version of x86_64 does no longer work on the latest nightly. updating the dependencies fixes this