### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ license = "MIT/Apache-2.0"
 maintenance = { status = "experimental" }
 
 [dependencies]
-x86_64 = "0.11"
+x86_64 = "0.13"
 raw-cpuid = "8.1"
 bit = "0.1.1"
 bitflags = "1.2"
-paste = "0.1"
+paste = "1.0"


### PR DESCRIPTION
This change updates the dependencies for `x86_64` and `paste` to their latest versions. This builds cleanly on my machine on `rustc 1.49.0 (e1884a8e3 2020-12-29)` and `rustc 1.51.0-nightly (44e3daf5e 2020-12-31)`.