### PR TITLE
Update `x86_64` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "MIT/Apache-2.0"
 maintenance = { status = "experimental" }
 
 [dependencies]
-x86_64 = "0.13"
+x86_64 = "0.14"
 raw-cpuid = "9.0.0"
 bit = "0.1.1"
 bitflags = "1.2"


### PR DESCRIPTION
This pull request bumps the `x86_64` dependency from 0.13 -> 0.14, fixing build errors in nightly 2021-05-11. With this change it builds cleanly on my machine.