### PR TITLE
Make the RedirectionTableEntry usable as a function parameter

### DIFF
--- a/src/ioapic/ioapic_regs.rs
+++ b/src/ioapic/ioapic_regs.rs
@@ -1,6 +1,6 @@
 use core::ptr::{self, Unique};
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct IoApicRegisters {
     ioregsel: Unique<u32>,
     ioregwin: Unique<u32>,

--- a/src/ioapic/irq_entry.rs
+++ b/src/ioapic/irq_entry.rs
@@ -69,7 +69,7 @@ bitflags! {
 }
 
 /// Redirection table entry.
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 pub struct RedirectionTableEntry {
     low: u32,
     high: u32,

--- a/src/ioapic/mod.rs
+++ b/src/ioapic/mod.rs
@@ -7,7 +7,7 @@ mod irq_entry;
 pub use irq_entry::{IrqFlags, IrqMode, RedirectionTableEntry};
 
 /// The IOAPIC structure.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct IoApic {
     regs: IoApicRegisters,
 }


### PR DESCRIPTION
In its current state, not implementing the Copy and Clone traits results in a “cannot move out of shared reference” error when attempting to define a helper function that takes the PIC, IRQ number, redirection table entry, and destination as parameters to eliminate the need to repeat oneself when needing to enable large numbers of IOAPIC IRQs.

This contribution solves the problem by deriving the Copy and Clone traits both in the RedirectionTableEntry and in the type of its sole member.