### PR TITLE
Allow the initialization of multiple IOAPIC IDs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "rust-analyzer.server.extraEnv": {
+        "CARGO": "/opt/rust/bin/cargo",
+        "RUSTC": "/opt/rust/bin/rustc"
+    },
+    "rust-analyzer.restartServerOnConfigChange": true,
+    "rust-analyzer.runnableEnv": {
+        "PATH": "/opt/rust/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl"
+    }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+[toolchain]
+channel = "nightly"
+components = [
+    "llvm-tools-preview",
+    "rust-src",
+    "rustc-dev",
+    "rustfmt",
+    "rust-analyzer-preview"
+]
+targets=["x86_64-unknown-none"]

--- a/src/lapic/builder.rs
+++ b/src/lapic/builder.rs
@@ -116,7 +116,7 @@ impl LocalApicBuilder {
         };
 
         let mut regs = LocalApicRegisters::new(mode);
-        
+
         if self.id.is_some() {
             unsafe { regs.write_id(self.id.unwrap()) };
         }

--- a/src/lapic/builder.rs
+++ b/src/lapic/builder.rs
@@ -119,8 +119,6 @@ impl LocalApicBuilder {
         
         if self.id.is_some() {
             unsafe { regs.write_id(self.id.unwrap()) };
-        } else {
-            unsafe { regs.id() };
         }
 
         if self.timer_vector.is_none()

--- a/src/lapic/lapic_msr.rs
+++ b/src/lapic/lapic_msr.rs
@@ -266,7 +266,7 @@ impl LocalApicRegisters {
         self.write_icr(icr);
     }
 
-    read!(id);
+    read_write!(id);
     read!(version);
     read_write!(tpr);
     read!(ppr);


### PR DESCRIPTION
The ability to (optionally) specify a custom APIC ID when building a local APIC is important for doing something like the following:

```rust
// snip
let lapic_vec = alloc::vec::Vec::new();
for topology in raw_cpuid::CpuId::new().get_extended_topology_info().unwrap() {
    let lapic_virt = todo!("offset the virtual address here");

    let lapic = LocalApicBuilder::new()
        .id(topology.x2apic_id())
        .timer_vector(todo!("specify timer vector here"))
        .error_vector(todo!("specify error vector here"))
        .spurious_vector(todo!("specify spurious vector here"))
        .set_xapic_base(lapic_virt)
        .build()
        .unwrap_or_else(|e| panic!("Error building local APICs: {:#?}", e));

    lapic_vec.push(lapic);
}
```
Without the ability to specify an ID when building, it's impossible to build (and subsequently enable) multiple LAPICs at once. So, submitting this pull request to make this possible.