### PR TITLE
Make the errors mapping table entries less cryptic

### DIFF
--- a/src/lapic/mod.rs
+++ b/src/lapic/mod.rs
@@ -269,16 +269,20 @@ impl LocalApic {
     }
 
     unsafe fn remap_lvt_entries(&mut self) {
-        self.regs.set_lvt_timer_bit_range(
-            LVT_TIMER_VECTOR,
-            self.timer_vector as u32,
-        );
-        self.regs.set_lvt_error_bit_range(
-            LVT_ERROR_VECTOR,
-            self.error_vector as u32,
-        );
-        self.regs
-            .set_sivr_bit_range(SIVR_VECTOR, self.spurious_vector as u32);
+        if self.timer_vector > 255 || self.error_vector > 255 || self.spurious_vector > 255 {
+            panic!("Vector entry too large: timer, error, and spurious vectors must be 8 bits in length");
+        } else {
+            self.regs.set_lvt_timer_bit_range(
+                LVT_TIMER_VECTOR,
+                self.timer_vector as u32,
+            );
+            self.regs.set_lvt_error_bit_range(
+                LVT_ERROR_VECTOR,
+                self.error_vector as u32,
+            );
+            self.regs
+                .set_sivr_bit_range(SIVR_VECTOR, self.spurious_vector as u32);
+        }
     }
 
     unsafe fn configure_timer(&mut self) {


### PR DESCRIPTION
I've spent [hours](https://github.com/phil-opp/blog_os/discussions/1014#discussioncomment-3303260) debugging the following panic message thrown when a value larger than the 8 bits defined in the timer and error vector constants (I was trying to put `0x320` in the timer vector field and `0x280` in the error vector field per what's specified on osdev.org) is plugged into the builder functions:

```
assertion failed: `(left == right)`
left: `3`
right: `0`
```

This message is coming from the `bit` crate, which performs an `assert_eq!` check to ensure that the bits are of the same length. Yet, it does absolutely nothing to inform the developer of what is being done wrong. So, I'm submitting this pull request to save other people the trouble by printing a more legible error message.