### PR TITLE
Bump version to 0.4.1 to take #11 to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x2apic"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Kevin Zhao <kzhao0986@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Without a version change, it’s impossible to get changes like those merged in #11 published.