### PR TITLE
Add getter for LAPIC IPI delivery status

### DIFF
--- a/src/lapic/lapic_msr.rs
+++ b/src/lapic/lapic_msr.rs
@@ -513,6 +513,7 @@ pub const ICR_DESTINATION: Range<usize> = 32..64;
 pub const ICR_DEST_SHORTHAND: Range<usize> = 18..20;
 pub const ICR_TRIGGER_MODE: usize = 15;
 pub const ICR_LEVEL: usize = 14;
+pub const ICR_DELIVERY_STATUS: usize = 12;
 pub const ICR_DESTINATION_MODE: usize = 11;
 pub const ICR_DELIVERY_MODE: Range<usize> = 8..11;
 pub const ICR_VECTOR: Range<usize> = 0..8;

--- a/src/lapic/mod.rs
+++ b/src/lapic/mod.rs
@@ -239,7 +239,7 @@ impl LocalApic {
         );
         self.regs.write_icr(icr_val);
     }
-    
+
     /// Sends an INIT IPI to the processors in `dest`.
     pub unsafe fn send_init_ipi(&mut self, dest: u32) {
         let mut icr_val = self.format_icr(0, IpiDeliveryMode::Init);
@@ -247,7 +247,7 @@ impl LocalApic {
         icr_val.set_bit_range(ICR_DESTINATION, u64::from(dest));
         self.regs.write_icr(icr_val);
     }
-    
+
     /// Sends an INIT IPI to all other processors.
     pub unsafe fn send_init_ipi_all(&mut self) {
         let mut icr_val = self.format_icr(0, IpiDeliveryMode::Init);
@@ -262,6 +262,11 @@ impl LocalApic {
     /// Issues an IPI to itself on vector `irq`.
     pub unsafe fn send_ipi_self(&mut self, vector: u8) {
         self.regs.write_self_ipi(u32::from(vector));
+    }
+
+    /// Return the delivery status of the last sent IPI.
+    pub unsafe fn get_ipi_delivery_status(&self) -> bool {
+        self.regs.icr_bit(ICR_DELIVERY_STATUS)
     }
 
     fn format_icr(&self, vector: u8, mode: IpiDeliveryMode) -> u64 {
@@ -288,7 +293,10 @@ impl LocalApic {
     }
 
     unsafe fn remap_lvt_entries(&mut self) {
-        if self.timer_vector > 255 || self.error_vector > 255 || self.spurious_vector > 255 {
+        if self.timer_vector > 255
+            || self.error_vector > 255
+            || self.spurious_vector > 255
+        {
             panic!("Vector entry too large: timer, error, and spurious vectors must be 8 bits in length");
         } else {
             self.regs.set_lvt_timer_bit_range(


### PR DESCRIPTION
This PR adds `LocalApic::get_ipi_delivery_status` to allow accessing bit 12 of ICR, which should be clear before the CPU sends another IPI.
(The formatting changes in `mod.rs` were caused by `cargo fmt`, I hope this is okay.)
Thank you for this crate! I've been using it for my own kernel and it has been very useful, but being unable to access this bit made sending IPIs properly difficult. I hope the PR is useful.